### PR TITLE
fix: implement QR code redirect flow for tree detail pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,16 +9,19 @@ import {
   CardHeader,
 } from "@/components/ui/card";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 
-export default function LoginPage() {
+function LoginContent() {
   const [isLoading, setIsLoading] = useState(false);
+  const searchParams = useSearchParams();
+  const redirectUrl = searchParams.get('redirect') || '/dashboard';
 
   const handleLogin = async () => {
     setIsLoading(true);
     await authClient.signIn.social({
       provider: "line",
-      callbackURL: "/dashboard",
+      callbackURL: redirectUrl,
     });
   };
 
@@ -73,5 +76,17 @@ export default function LoginPage() {
         </CardFooter>
       </Card>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-[#26623d] border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    }>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/components/dashboard/views/dashboard-view.tsx
+++ b/components/dashboard/views/dashboard-view.tsx
@@ -110,21 +110,22 @@ export function DashboardView({ onViewChange, onIdentifyTree }: DashboardViewPro
       
       setIsGeneratingQR(true);
       const data = await Promise.all(processedTrees.map(async (tree) => {
-        // Current host logic placeholder - ideally use ENV or window.location
+        // Generate QR code that points to login with redirect to tree detail
         const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://clurian.com';
-        const url = `${baseUrl}/dashboard?treeId=${tree.id}`;
+        const treeDetailUrl = `${baseUrl}/dashboard?treeId=${tree.id}`;
+        const loginUrl = `${baseUrl}/login?redirect=${encodeURIComponent(treeDetailUrl)}`;
         
         try {
-          const qrDataUrl = await QRCode.toDataURL(url);
+          const qrDataUrl = await QRCode.toDataURL(loginUrl);
           return {
             ...tree,
             plantedDate: tree.plantedDate, // Ensure this field exists
-            url,
+            url: loginUrl,
             qrDataUrl
           };
         } catch (e) {
           console.error('QR Gen Error', e);
-          return { ...tree, url };
+          return { ...tree, url: loginUrl };
         }
       }));
       setQrData(data);


### PR DESCRIPTION
- Updated login page to accept 'redirect' query parameter
- Added Suspense boundary for useSearchParams in login page
- Modified QR code generation to include login with tree detail redirect
- QR codes now point to: /login?redirect=/dashboard?treeId=<ID>
- After login, users are redirected to the tree detail page
- Fixed deep linking from QR code scans
- User can now scan QR code -> login -> automatically see tree details

Flow:
1. User scans QR code from PDF
2. Opens login page with redirect parameter
3. Completes LINE authentication
4. Automatically redirected to tree detail view