### PR TITLE
feat: add loading spinner to tree cards to fix dead click UX issue

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -35,6 +35,7 @@ function DashboardContent() {
   // --- State ---
   const [view, setView] = useState<ViewState>('dashboard');
   const [selectedTreeId, setSelectedTreeId] = useState<string | null>(null);
+  const [loadingTreeId, setLoadingTreeId] = useState<string | null>(null);
 
   const selectedTree = trees.find(t => t.id === selectedTreeId);
 
@@ -45,18 +46,21 @@ function DashboardContent() {
       if (trees.some(t => t.id === treeId)) {
         setSelectedTreeId(treeId);
         setView('tree_detail');
+        setLoadingTreeId(null); // Clear loading state when view is shown
       }
     } else if (!treeId && view === 'tree_detail') {
       // If no treeId in URL but view is tree_detail, go back to dashboard
       setView('dashboard');
       setSelectedTreeId(null);
+      setLoadingTreeId(null);
     }
-  }, [searchParams, trees]);
+  }, [searchParams, trees, view]);
 
 
   // --- Actions ---
 
   const handleIdentifyTree = (treeId: string) => {
+    setLoadingTreeId(treeId);
     router.replace(`/dashboard?treeId=${treeId}`, { scroll: false });
   };
 
@@ -147,6 +151,7 @@ function DashboardContent() {
         <DashboardView 
             onViewChange={setView}
             onIdentifyTree={handleIdentifyTree}
+            loadingTreeId={loadingTreeId}
         />
      );
   }

--- a/components/dashboard/views/dashboard-view.tsx
+++ b/components/dashboard/views/dashboard-view.tsx
@@ -15,9 +15,10 @@ import { Search, Sprout, PlusCircle, ClipboardList, Printer } from "lucide-react
 interface DashboardViewProps {
   onViewChange: (view: 'add_tree' | 'add_batch_log' | 'tree_detail') => void;
   onIdentifyTree: (treeId: string) => void;
+  loadingTreeId?: string | null;
 }
 
-export function DashboardView({ onViewChange, onIdentifyTree }: DashboardViewProps) {
+export function DashboardView({ onViewChange, onIdentifyTree, loadingTreeId }: DashboardViewProps) {
   const { trees, currentOrchardId, currentOrchard } = useOrchard();
   
   const [filterZone, setFilterZone] = useState(ZONE_FILTER_ALL);
@@ -154,7 +155,10 @@ export function DashboardView({ onViewChange, onIdentifyTree }: DashboardViewPro
         ) : (
             paginatedTrees.data.map(tree => (
                 <div key={tree.id} onClick={() => onIdentifyTree(tree.id)}>
-                    <TreeCard tree={tree} />
+                    <TreeCard 
+                        tree={tree} 
+                        isLoading={loadingTreeId === tree.id}
+                    />
                 </div>
             ))
         )}

--- a/components/tree-card.tsx
+++ b/components/tree-card.tsx
@@ -8,6 +8,7 @@ import type { Tree } from "@/lib/types";
 export interface TreeCardProps {
   tree: Tree;
   onClick?: () => void;
+  isLoading?: boolean;
   className?: string;
 }
 
@@ -18,26 +19,33 @@ export interface TreeCardProps {
  * <TreeCard
  *   tree={tree}
  *   onClick={() => router.push(`/tree/${tree.id}`)}
+ *   isLoading={loadingTreeId === tree.id}
  * />
  */
-export function TreeCard({ tree, onClick, className }: TreeCardProps) {
+export function TreeCard({ tree, onClick, isLoading, className }: TreeCardProps) {
   const age = getTreeAge(tree.plantedDate);
 
   return (
     <button
       onClick={onClick}
+      disabled={isLoading}
       className={cn(
         "w-full bg-card hover:bg-muted/50 p-4 rounded-xl shadow-sm border border-border",
         "flex items-center justify-between gap-3",
         "transition-colors cursor-pointer text-left",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+        "disabled:opacity-70 disabled:cursor-not-allowed",
         className
       )}
     >
       <div className="flex items-center gap-3 min-w-0">
         {/* Tree code badge */}
         <div className="bg-primary text-primary-foreground rounded-lg w-12 h-12 flex items-center justify-center font-bold text-sm shrink-0">
-          {tree.code}
+          {isLoading ? (
+            <div className="animate-spin h-5 w-5 border-2 border-primary-foreground border-t-transparent rounded-full" />
+          ) : (
+            tree.code
+          )}
         </div>
 
         {/* Tree info */}
@@ -58,7 +66,10 @@ export function TreeCard({ tree, onClick, className }: TreeCardProps) {
       </div>
 
       {/* Arrow indicator */}
-      <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
+      <ChevronRight className={cn(
+        "h-5 w-5 text-muted-foreground shrink-0",
+        isLoading && "opacity-50"
+      )} />
     </button>
   );
 }


### PR DESCRIPTION
- Add isLoading prop to TreeCard component with animated spinner
- Implement loading state tracking in dashboard page when clicking tree cards
- Show spinner in tree code badge area while navigating to detail view
- Disable card interaction and reduce opacity during loading
- Prevent multiple clicks on same card with disabled state
- Clear loading state when tree detail view is successfully shown

This resolves the 'dead click' issue where users got no visual feedback when clicking on tree cards. Users now see immediate spinner feedback and cards are disabled during navigation.