### PR TITLE
fix: remove hardcoded loading state in tree detail log form

### DIFF
--- a/components/dashboard/views/tree-detail-view.tsx
+++ b/components/dashboard/views/tree-detail-view.tsx
@@ -22,6 +22,7 @@ export function TreeDetailView({ tree, onBack }: TreeDetailViewProps) {
   
   // Local State
   const [isAddingLog, setIsAddingLog] = useState(false);
+  const [isSubmittingLog, setIsSubmittingLog] = useState(false);
   const [viewLog, setViewLog] = useState<Log | null>(null);
   const [followUpLog, setFollowUpLog] = useState<Log | null>(null);
 
@@ -101,6 +102,7 @@ export function TreeDetailView({ tree, onBack }: TreeDetailViewProps) {
   }
 
   const handleAddLogSubmit = async (data: LogSubmissionData) => {
+    setIsSubmittingLog(true);
     try {
       await addLog({
           ...data,
@@ -114,6 +116,8 @@ export function TreeDetailView({ tree, onBack }: TreeDetailViewProps) {
     } catch (error) {
       console.error('Failed to add log:', error);
       alert('เกิดข้อผิดพลาดในการบันทึกข้อมูล กรุณาลองใหม่อีกครั้ง');
+    } finally {
+      setIsSubmittingLog(false);
     }
   };
 
@@ -129,7 +133,7 @@ export function TreeDetailView({ tree, onBack }: TreeDetailViewProps) {
               zones={[]}
               isBatch={false}
               treeCode={tree.code}
-              isLoading={true}
+              isLoading={isSubmittingLog}
           />
       );
   }


### PR DESCRIPTION
- Add separate isSubmittingLog state to track actual form submission
- Fix hardcoded isLoading={true} that prevented form interaction
- Form now starts with enabled inputs and only shows loading during submission
- Maintain proper loading state with try-catch-finally pattern
- Prevents immediate disabled state when opening add log form

The curse was the hardcoded isLoading={true} that made the form permanently loading on render!

🤖 Generated with [Claude Code](https://claude.com/claude-code)